### PR TITLE
Add users owned sets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma', '~> 4.1'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 gem 'pry'
 gem 'dotenv-rails'
 gem 'fast_jsonapi'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    bcrypt (3.1.16)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -159,6 +160,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
   dotenv-rails

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/models/lego_set.rb
+++ b/app/models/lego_set.rb
@@ -1,5 +1,7 @@
 class LegoSet < ApplicationRecord
     belongs_to :theme
+    has_many :owned_sets
+    has_many :users, through: :owned_sets
     has_many :set_part_specs, dependent: :destroy
     has_many :parts, through: :set_part_specs
 

--- a/app/models/owned_set.rb
+++ b/app/models/owned_set.rb
@@ -1,0 +1,2 @@
+class OwnedSet < ApplicationRecord
+end

--- a/app/models/owned_set.rb
+++ b/app/models/owned_set.rb
@@ -1,2 +1,4 @@
 class OwnedSet < ApplicationRecord
+    belongs_to :user
+    belongs_to :lego_set
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,9 @@
 class User < ApplicationRecord
+    has_secure_password
     validates :email, uniqueness: {case_sensitive: false}
     before_validation :downcase_email
-    has_secure_password
+    has_many :owned_sets
+    has_many :lego_sets, through: :owned_sets
 
     def downcase_email
         self.email = self.email.downcase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
     validates :email, uniqueness: {case_sensitive: false}
     before_validation :downcase_email
+    has_secure_password
 
     def downcase_email
         self.email = self.email.downcase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,8 @@
 class User < ApplicationRecord
     validates :email, uniqueness: {case_sensitive: false}
+    before_validation :downcase_email
+
+    def downcase_email
+        self.email = self.email.downcase
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+    validates :email, uniqueness: {case_sensitive: false}
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   
+  resources :users
   get "/lego_sets/owned", to: "lego_sets#owned_sets", as: "owned_sets"
   get "/lego_sets/potential_builds/:strictParam", to: "lego_sets#potential_builds", as: "potential_builds"
 

--- a/db/migrate/20211002133536_create_users.rb
+++ b/db/migrate/20211002133536_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211002141853_create_owned_sets.rb
+++ b/db/migrate/20211002141853_create_owned_sets.rb
@@ -1,0 +1,10 @@
+class CreateOwnedSets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :owned_sets do |t|
+      t.integer :lego_set_id
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_27_204400) do
+ActiveRecord::Schema.define(version: 2021_10_02_133536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,14 @@ ActiveRecord::Schema.define(version: 2021_06_27_204400) do
   create_table "themes", force: :cascade do |t|
     t.string "theme_number"
     t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_02_133536) do
+ActiveRecord::Schema.define(version: 2021_10_02_141853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,13 @@ ActiveRecord::Schema.define(version: 2021_10_02_133536) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "potential_build_strict"
+  end
+
+  create_table "owned_sets", force: :cascade do |t|
+    t.integer "lego_set_id"
+    t.integer "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "part_categories", force: :cascade do |t|

--- a/test/fixtures/owned_sets.yml
+++ b/test/fixtures/owned_sets.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  lego_set_id: 1
+  user_id: 1
+
+two:
+  lego_set_id: 1
+  user_id: 1

--- a/test/models/owned_set_test.rb
+++ b/test/models/owned_set_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class OwnedSetTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Add users and owned_sets models, tables for both, but controller only for users; add bcrypt and has_secure_password; add table and model relations.

Todo: change .owned_sets method in lego_set model to use current_user.owned_sets after setting up current_user.